### PR TITLE
Implement Trusted Advisor refresh lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+function.zip
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
-# Ministry of Justice Template Repository
+# modernisation-platform-terraform-trusted-advisor
 
-Use this template to [create a repository] with the default initial files for a Ministry of Justice Github repository, including:
+Terraform module to refresh [AWS Trusted Advisor](https://aws.amazon.com/premiumsupport/technology/trusted-advisor/).
 
-* The correct LICENSE
-* Github actions
-* .gitignore file
+>This uses the AWS Support API, which is only available in us-east-1.
 
-Once you have created your repository, please:
+## Usage
 
-* Edit the copy of this README.md file to document your project
-* Grant permissions to the appropriate MoJ teams
-* Setup branch protection
+```
+module "trusted-advisor" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-trusted-advisor"
+}
+```
 
-[create a repository]: https://github.com/ministryofjustice/template-repository/generate
+## Inputs
+| Name | Description                | Type | Default | Required |
+|------|----------------------------|------|---------|----------|
+| tags | Tags to apply to resources | map  | {}      | no       |
+
+## Outputs
+None.
+
+## Looking for issues?
+If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).

--- a/function/index.js
+++ b/function/index.js
@@ -1,0 +1,34 @@
+const utilities = require('./utilities.js')
+
+exports.handler = async (event, context) => {
+  // Get Trusted Advisor checks
+  const checks = await utilities.describeTrustedAdvisorChecks()
+  const results = { success: [], errors: [] }
+
+  // Loop through the checks and return their result, whether they succeed or not
+  await Promise.all(checks.map(async check => {
+    if (!utilities.unrefreshableChecks.includes(check.id) && !utilities.removedChecks.includes(check.id)) {
+      console.log(`[info] Refreshing ${check.name} (ID: ${check.id})`)
+
+      // Refresh each check individually (there's no batch API endpoint)
+      await utilities.refreshTrustedAdvisorCheck(check.id).then(result => {
+        console.log(`[success] Refreshed ${check.name} (ID: ${check.id}) successfully`)
+        results.success.push(result)
+      }).catch(error => {
+        console.log(`[error] Cannot refresh ${check.name} (ID: ${check.id})`)
+        results.errors.push(error)
+      })
+    }
+  }))
+
+  // Print out some errors if there are any
+  if (results.errors.length) {
+    console.log('[error] For errors, please see below:')
+    results.errors.forEach(error => {
+      console.log(error)
+    })
+  }
+
+  // Output our finished statement
+  console.log(`[finished] ${results.success.length}/${results.success.length + results.errors.length} refreshed.`)
+}

--- a/function/package-lock.json
+++ b/function/package-lock.json
@@ -1,0 +1,116 @@
+{
+  "name": "modernisation-platform-terraform-trusted-advisor",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aws-sdk": {
+      "version": "2.784.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.784.0.tgz",
+      "integrity": "sha512-+KBkqH7t/XE91Fqn8eyJeNIWsnhSWL8bSUqFD7TfE3FN07MTlC0nprGYp+2WfcYNz5i8Bus1vY2DHNVhtTImnw==",
+      "dev": true,
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
+    }
+  }
+}

--- a/function/package.json
+++ b/function/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "modernisation-platform-terraform-trusted-advisor",
+  "version": "1.0.0",
+  "description": "Lambda to refresh AWS Trusted Advisor",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ministryofjustice/modernisation-platform-terraform-trusted-advisor.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ministryofjustice/modernisation-platform/issues"
+  },
+  "homepage": "https://github.com/ministryofjustice/modernisation-platform-terraform-trusted-advisor#readme",
+  "devDependencies": {
+    "aws-sdk": "^2.784.0"
+  }
+}

--- a/function/utilities.js
+++ b/function/utilities.js
@@ -1,0 +1,48 @@
+const AWS = require('aws-sdk')
+const support = new AWS.Support({
+  apiVersion: '2013-04-15',
+  region: 'us-east-1' // AWS Support API is only accessible from the us-east-1 region
+})
+
+const utilities = {
+  /*
+    These checks are being removed on November 18, 2020
+    See: https://docs.aws.amazon.com/awssupport/latest/user/trusted-advisor.html
+  */
+  removedChecks: [
+    'fH7LL0l7J9', // EBS Active Volumes
+    'TyfdMXG69d', // ENA Driver Version for EC2 Windows Instances
+    'V77iOLlBqz', // EC2Config Service for EC2 Windows Instances
+    'Wnwm9Il5bG', // PV Driver Version for EC2 Windows Instances
+    'yHAGQJV9K5' // NVMe Driver Version for EC2 Windows Instances
+  ],
+  /*
+    These checks aren't refreshable via the API.
+    This isn't included in the AWS documentation,
+    but it is mentioned in the Trusted Advisor console.
+
+    These checks are automatically refreshed multiple times a day by AWS.
+  */
+  unrefreshableChecks: [
+    '0t121N1Ty3', // AWS Direct Connect Connection Redundancy
+    '4g3Nt5M1Th', // AWS Direct Connect Virtual Interface Redundancy
+    '8M012Ph3U5', // AWS Direct Connect Location Redundancy
+    'ePs02jT06w', // Amazon EBS Public Snapshots
+    'rSs93HQwa1' // Amazon RDS Public Snapshots
+  ],
+  describeTrustedAdvisorChecks () {
+    return support.describeTrustedAdvisorChecks({
+      language: 'en'
+    }).promise().then(data => data.checks).catch(error => {
+      console.log('[error] Cannot run support.describeTrustedAdvisorChecks:', error)
+      throw new Error(error)
+    })
+  },
+  refreshTrustedAdvisorCheck (checkId) {
+    return support.refreshTrustedAdvisorCheck({
+      checkId: checkId
+    }).promise()
+  }
+}
+
+module.exports = utilities

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,123 @@
+# This is used for the Lambda name and CloudWatch Log group, which is automatically created by AWS
+# but we can manage it via Terraform if we use the same name
+locals {
+  name = "trusted-advisor-refresh"
+}
+
+# IAM role
+data "aws_iam_policy_document" "assume-role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "default" {
+  # Allow the function to write logs
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+
+    resources = ["${aws_cloudwatch_log_group.default.arn}:*"]
+  }
+
+  # Support doesn't allow you to target individual resources, so we need to use *
+  statement {
+    effect = "Allow"
+    actions = [
+      "support:DescribeTrustedAdvisorChecks",
+      "support:RefreshTrustedAdvisorCheck"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "default" {
+  name   = local.name
+  policy = data.aws_iam_policy_document.default.json
+}
+
+resource "aws_iam_role_policy_attachment" "default" {
+  role       = aws_iam_role.default.name
+  policy_arn = aws_iam_policy.default.arn
+}
+
+resource "aws_iam_role" "default" {
+  name               = "AWSTrustedAdvisorRefresh"
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
+}
+
+# CloudWatch Log
+resource "aws_cloudwatch_log_group" "default" {
+  name              = "/aws/lambda/${local.name}"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
+# EventBridge (previously known as CloudWatch) scheduled event
+resource "aws_cloudwatch_event_rule" "default" {
+  name                = "run-${local.name}-hourly"
+  description         = "Scheduled event for ${local.name}"
+  schedule_expression = "rate(60 minutes)"
+}
+
+resource "aws_cloudwatch_event_target" "default" {
+  rule = aws_cloudwatch_event_rule.default.name
+  arn  = aws_lambda_function.default.arn
+}
+
+# Lambda function
+## ZIP up the function
+data "archive_file" "function" {
+  type        = "zip"
+  output_path = "${path.module}/function.zip"
+
+  source {
+    content  = file("${path.module}/function/index.js")
+    filename = "index.js"
+  }
+
+  source {
+    content  = file("${path.module}/function/utilities.js")
+    filename = "utilities.js"
+  }
+
+  source {
+    content  = file("${path.module}/function/package.json")
+    filename = "package.json"
+  }
+}
+
+## Give CloudWatch permission to run it (via a Scheduled Event)
+resource "aws_lambda_permission" "default" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.default.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.default.arn
+}
+
+## Create the Lambda function
+resource "aws_lambda_function" "default" {
+  filename         = data.archive_file.function.output_path
+  function_name    = local.name
+  handler          = "index.handler"
+  role             = aws_iam_role.default.arn
+  runtime          = "nodejs12.x"
+  source_code_hash = data.archive_file.function.output_base64sha256
+  timeout          = "60"
+
+  depends_on = [
+    data.archive_file.function,
+    aws_cloudwatch_log_group.default
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,5 @@
+variable "tags" {
+  type        = map
+  description = "Tags to apply to resources, where applicable"
+  default     = {}
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    archive = {
+      source = "hashicorp/archive"
+    }
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}


### PR DESCRIPTION
This creates the following infrastructure:
- Lambda function to call the Support API to refresh Trusted Advisor checks
- EventBridge (CloudWatch Events) schedule and rule to run the function every 60 minutes
- IAM role to run the Lambda function from EventBridge