### PR TITLE
Fix versions, variables and add outputs.tf file

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "tags" {
-  type        = map
+  type        = map(any)
   description = "Tags to apply to resources, where applicable"
   default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,10 +2,12 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     archive = {
-      source = "hashicorp/archive"
+      source  = "hashicorp/archive"
+      version = ">= 2.0.0"
     }
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
 }


### PR DESCRIPTION
This PR fixes provider versions to use the correct minimum `aws` and `archive` provider versions.

It also adds an empty `outputs.tf` file to match the best practices for [module code structure](https://www.terraform-best-practices.com/code-structure#getting-started-with-structuring-of-terraform-configurations).

Once this is merged we can release v1.0.0 of this, so we can pin it as part of ministryofjustice/modernisation-platform#72.