### PR TITLE
AWS Provider 5.0 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ function.zip
 node_modules
 .tfsec
 .idea
+.terraform
+.terraform.lock.hcl

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.47.0"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
Bumps version constraint to ~> 5.0.
Related to https://github.com/ministryofjustice/modernisation-platform/issues/4173