### PR TITLE
Stop tfsec errors

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,8 +19,11 @@ data "aws_iam_policy_document" "assume-role" {
 
 data "aws_iam_policy_document" "default" {
   # Allow the function to write logs
+  # Ignore this check on tfsec - it causes a fail on resources *. The resource * allows the lambda (below) to access groups it needs to run
+  #tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
     effect = "Allow"
+    
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
@@ -58,6 +61,7 @@ resource "aws_iam_role" "default" {
 
 # CloudWatch Log
 # Logs do not contain sensitive data
+# Ignore tfsec check. Gives a "low" error on log group not encrypted. 
 # tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "default" {
 

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "default" {
   #tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
     effect = "Allow"
-    
+
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",


### PR DESCRIPTION
Various errors were popping up on tfsec which we couldn't see. After loading tfsec and running it manually in the code area we found the issues. To fix the one that kept popping up (resources * on iam allow) a tfsec ignore was added to the code. It was needed in two places due to an encryption issue.